### PR TITLE
Update splitting.py

### DIFF
--- a/RandomForest/splitting.py
+++ b/RandomForest/splitting.py
@@ -26,8 +26,10 @@ def _split(X_column, split_thr):
 def _gini_split(left_y, right_y, n_classes, len_y):  
     if len(left_y) == 0 or len(right_y) == 0:
         return 1
-    gini_left = 1.0 - np.sum((np.bincount(left_y, minlength=n_classes) / len(left_y)) ** 2)
-    gini_right = 1.0 - np.sum((np.bincount(right_y, minlength=n_classes) / len(right_y)) ** 2)
+    # Now, the code works even if the target variable is float like 1.0
+    # Still, the code does NOT work if the Target variable is str like "Yes"
+    gini_left = 1.0 - np.sum((np.bincount(left_y.astype('int'), minlength=n_classes) / len(left_y.astype('int'))) ** 2)
+    gini_right = 1.0 - np.sum((np.bincount(right_y.astype('int'), minlength=n_classes) / len(right_y.astype('int'))) ** 2)
     gini = (len(left_y) / len_y) * gini_left + (len(right_y) / len_y) * gini_right
     return gini
 


### PR DESCRIPTION
# Now, the code works even if the target variable is float like 1.0 or 0.0 `np.bicount`  expects the input array to have integers. 

Instead of changing the file reading at states.py, I changed it here as this would not hurt the future development of the app toward regression problems.  For regression problems, calculating the Gini score will need to go through a different computational path, but reading input files at states.py will remain the same. 



    # Still, the code does NOT work if the Target variable is str like "Yes." 
One must add to readme this warning. 

Previous requirement: all features except the target should be numerical, but the target must be int. 

Current requirement: all entries, including target, have to be numerical in the data, int or float.